### PR TITLE
Fetch images from reddit, as the old API is down

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,9 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/src",
+			"outFiles": [
+				"${workspaceRoot}/out/src"
+			],
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +23,9 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/test",
+			"outFiles": [ 
+				"${workspaceRoot}/out/test"
+			],
 			"preLaunchTask": "npm"
 		}
 	]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1987 @@
+{
+ "name": "puppypopup",
+ "version": "0.0.2",
+ "lockfileVersion": 1,
+ "requires": true,
+ "dependencies": {
+  "amdefine": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+   "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+   "dev": true
+  },
+  "ansi-regex": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+   "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+   "dev": true
+  },
+  "ansi-styles": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+   "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+   "dev": true
+  },
+  "arr-diff": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+   "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+   "dev": true,
+   "requires": {
+    "arr-flatten": "1.1.0"
+   }
+  },
+  "arr-flatten": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+   "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+   "dev": true
+  },
+  "array-unique": {
+   "version": "0.2.1",
+   "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+   "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+   "dev": true
+  },
+  "asn1": {
+   "version": "0.2.3",
+   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+   "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+   "dev": true
+  },
+  "assert-plus": {
+   "version": "0.2.0",
+   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+   "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+   "dev": true
+  },
+  "asynckit": {
+   "version": "0.4.0",
+   "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+   "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+   "dev": true
+  },
+  "aws-sign2": {
+   "version": "0.6.0",
+   "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+   "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+   "dev": true
+  },
+  "aws4": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+   "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+   "dev": true
+  },
+  "balanced-match": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+   "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+   "dev": true
+  },
+  "bcrypt-pbkdf": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+   "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+   "dev": true,
+   "optional": true,
+   "requires": {
+    "tweetnacl": "0.14.5"
+   }
+  },
+  "boom": {
+   "version": "2.10.1",
+   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+   "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+   "dev": true,
+   "requires": {
+    "hoek": "2.16.3"
+   }
+  },
+  "brace-expansion": {
+   "version": "1.1.8",
+   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+   "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+   "dev": true,
+   "requires": {
+    "balanced-match": "1.0.0",
+    "concat-map": "0.0.1"
+   }
+  },
+  "braces": {
+   "version": "1.8.5",
+   "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+   "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+   "dev": true,
+   "requires": {
+    "expand-range": "1.8.2",
+    "preserve": "0.2.0",
+    "repeat-element": "1.1.2"
+   }
+  },
+  "buffer-crc32": {
+   "version": "0.2.13",
+   "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+   "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+   "dev": true
+  },
+  "capture-stack-trace": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+   "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+  },
+  "caseless": {
+   "version": "0.11.0",
+   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+   "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+   "dev": true
+  },
+  "chalk": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+   "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+   "dev": true,
+   "requires": {
+    "ansi-styles": "2.2.1",
+    "escape-string-regexp": "1.0.5",
+    "has-ansi": "2.0.0",
+    "strip-ansi": "3.0.1",
+    "supports-color": "2.0.0"
+   }
+  },
+  "clone": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+   "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+   "dev": true
+  },
+  "clone-buffer": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+   "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+   "dev": true
+  },
+  "clone-stats": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+   "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+   "dev": true
+  },
+  "cloneable-readable": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+   "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
+   "dev": true,
+   "requires": {
+    "inherits": "2.0.3",
+    "process-nextick-args": "1.0.7",
+    "through2": "2.0.3"
+   }
+  },
+  "coffee-script": {
+   "version": "1.6.3",
+   "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.3.tgz",
+   "integrity": "sha1-Y1XTLPGwTN/2tITl5xF4Ky8MOb4="
+  },
+  "combined-stream": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+   "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+   "dev": true,
+   "requires": {
+    "delayed-stream": "1.0.0"
+   }
+  },
+  "commander": {
+   "version": "2.11.0",
+   "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+   "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+   "dev": true
+  },
+  "concat-map": {
+   "version": "0.0.1",
+   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+   "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+   "dev": true
+  },
+  "convert-source-map": {
+   "version": "1.5.0",
+   "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+   "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+   "dev": true
+  },
+  "core-util-is": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+   "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+   "dev": true
+  },
+  "create-error-class": {
+   "version": "3.0.2",
+   "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+   "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+   "requires": {
+    "capture-stack-trace": "1.0.0"
+   }
+  },
+  "cryptiles": {
+   "version": "2.0.5",
+   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+   "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+   "dev": true,
+   "requires": {
+    "boom": "2.10.1"
+   }
+  },
+  "dashdash": {
+   "version": "1.14.1",
+   "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+   "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+   "dev": true,
+   "requires": {
+    "assert-plus": "1.0.0"
+   },
+   "dependencies": {
+    "assert-plus": {
+     "version": "1.0.0",
+     "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+     "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+     "dev": true
+    }
+   }
+  },
+  "debug": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+   "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+   "dev": true,
+   "requires": {
+    "ms": "0.7.1"
+   }
+  },
+  "delayed-stream": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+   "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+   "dev": true
+  },
+  "dfrrd": {
+   "version": "0.2.0",
+   "resolved": "https://registry.npmjs.org/dfrrd/-/dfrrd-0.2.0.tgz",
+   "integrity": "sha1-ppI47LCMDr977EoPxQS5E+qKKK4="
+  },
+  "diff": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+   "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+   "dev": true
+  },
+  "duplexer": {
+   "version": "0.1.1",
+   "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+   "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+   "dev": true
+  },
+  "duplexer3": {
+   "version": "0.1.4",
+   "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+   "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+  },
+  "duplexify": {
+   "version": "3.5.0",
+   "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
+   "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
+   "dev": true,
+   "requires": {
+    "end-of-stream": "1.0.0",
+    "inherits": "2.0.3",
+    "readable-stream": "2.3.3",
+    "stream-shift": "1.0.0"
+   }
+  },
+  "ecc-jsbn": {
+   "version": "0.1.1",
+   "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+   "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+   "dev": true,
+   "optional": true,
+   "requires": {
+    "jsbn": "0.1.1"
+   }
+  },
+  "end-of-stream": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+   "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
+   "dev": true,
+   "requires": {
+    "once": "1.3.3"
+   },
+   "dependencies": {
+    "once": {
+     "version": "1.3.3",
+     "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+     "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+     "dev": true,
+     "requires": {
+      "wrappy": "1.0.2"
+     }
+    }
+   }
+  },
+  "escape-string-regexp": {
+   "version": "1.0.5",
+   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+   "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+   "dev": true
+  },
+  "event-stream": {
+   "version": "3.3.4",
+   "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+   "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+   "dev": true,
+   "requires": {
+    "duplexer": "0.1.1",
+    "from": "0.1.7",
+    "map-stream": "0.1.0",
+    "pause-stream": "0.0.11",
+    "split": "0.3.3",
+    "stream-combiner": "0.0.4",
+    "through": "2.3.8"
+   }
+  },
+  "eventemitter3": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+   "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+  },
+  "expand-brackets": {
+   "version": "0.1.5",
+   "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+   "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+   "dev": true,
+   "requires": {
+    "is-posix-bracket": "0.1.1"
+   }
+  },
+  "expand-range": {
+   "version": "1.8.2",
+   "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+   "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+   "dev": true,
+   "requires": {
+    "fill-range": "2.2.3"
+   }
+  },
+  "extend": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+   "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+   "dev": true
+  },
+  "extend-shallow": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+   "dev": true,
+   "requires": {
+    "is-extendable": "0.1.1"
+   }
+  },
+  "extglob": {
+   "version": "0.3.2",
+   "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+   "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+   "dev": true,
+   "requires": {
+    "is-extglob": "1.0.0"
+   },
+   "dependencies": {
+    "is-extglob": {
+     "version": "1.0.0",
+     "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+     "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+     "dev": true
+    }
+   }
+  },
+  "extsprintf": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+   "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+   "dev": true
+  },
+  "fd-slicer": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+   "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+   "dev": true,
+   "requires": {
+    "pend": "1.2.0"
+   }
+  },
+  "filename-regex": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+   "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+   "dev": true
+  },
+  "fill-range": {
+   "version": "2.2.3",
+   "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+   "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+   "dev": true,
+   "requires": {
+    "is-number": "2.1.0",
+    "isobject": "2.1.0",
+    "randomatic": "1.1.7",
+    "repeat-element": "1.1.2",
+    "repeat-string": "1.6.1"
+   }
+  },
+  "first-chunk-stream": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+   "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
+   "dev": true
+  },
+  "for-in": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+   "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+   "dev": true
+  },
+  "for-own": {
+   "version": "0.1.5",
+   "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+   "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+   "dev": true,
+   "requires": {
+    "for-in": "1.0.2"
+   }
+  },
+  "forever-agent": {
+   "version": "0.6.1",
+   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+   "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+   "dev": true
+  },
+  "form-data": {
+   "version": "2.1.4",
+   "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+   "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+   "dev": true,
+   "requires": {
+    "asynckit": "0.4.0",
+    "combined-stream": "1.0.5",
+    "mime-types": "2.1.15"
+   }
+  },
+  "from": {
+   "version": "0.1.7",
+   "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+   "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+   "dev": true
+  },
+  "generate-function": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+   "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+   "dev": true
+  },
+  "generate-object-property": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+   "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+   "dev": true,
+   "requires": {
+    "is-property": "1.0.2"
+   }
+  },
+  "get-stream": {
+   "version": "3.0.0",
+   "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+   "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+  },
+  "getpass": {
+   "version": "0.1.7",
+   "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+   "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+   "dev": true,
+   "requires": {
+    "assert-plus": "1.0.0"
+   },
+   "dependencies": {
+    "assert-plus": {
+     "version": "1.0.0",
+     "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+     "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+     "dev": true
+    }
+   }
+  },
+  "glob": {
+   "version": "5.0.15",
+   "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+   "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+   "dev": true,
+   "requires": {
+    "inflight": "1.0.6",
+    "inherits": "2.0.3",
+    "minimatch": "3.0.4",
+    "once": "1.4.0",
+    "path-is-absolute": "1.0.1"
+   }
+  },
+  "glob-base": {
+   "version": "0.3.0",
+   "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+   "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+   "dev": true,
+   "requires": {
+    "glob-parent": "2.0.0",
+    "is-glob": "2.0.1"
+   },
+   "dependencies": {
+    "glob-parent": {
+     "version": "2.0.0",
+     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+     "dev": true,
+     "requires": {
+      "is-glob": "2.0.1"
+     }
+    },
+    "is-extglob": {
+     "version": "1.0.0",
+     "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+     "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+     "dev": true
+    },
+    "is-glob": {
+     "version": "2.0.1",
+     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+     "dev": true,
+     "requires": {
+      "is-extglob": "1.0.0"
+     }
+    }
+   }
+  },
+  "glob-parent": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+   "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+   "dev": true,
+   "requires": {
+    "is-glob": "3.1.0",
+    "path-dirname": "1.0.2"
+   }
+  },
+  "glob-stream": {
+   "version": "5.3.5",
+   "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+   "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+   "dev": true,
+   "requires": {
+    "extend": "3.0.1",
+    "glob": "5.0.15",
+    "glob-parent": "3.1.0",
+    "micromatch": "2.3.11",
+    "ordered-read-streams": "0.3.0",
+    "through2": "0.6.5",
+    "to-absolute-glob": "0.1.1",
+    "unique-stream": "2.2.1"
+   },
+   "dependencies": {
+    "isarray": {
+     "version": "0.0.1",
+     "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+     "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+     "dev": true
+    },
+    "readable-stream": {
+     "version": "1.0.34",
+     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+     "dev": true,
+     "requires": {
+      "core-util-is": "1.0.2",
+      "inherits": "2.0.3",
+      "isarray": "0.0.1",
+      "string_decoder": "0.10.31"
+     }
+    },
+    "string_decoder": {
+     "version": "0.10.31",
+     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+     "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+     "dev": true
+    },
+    "through2": {
+     "version": "0.6.5",
+     "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+     "dev": true,
+     "requires": {
+      "readable-stream": "1.0.34",
+      "xtend": "4.0.1"
+     }
+    }
+   }
+  },
+  "got": {
+   "version": "6.7.1",
+   "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+   "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+   "requires": {
+    "create-error-class": "3.0.2",
+    "duplexer3": "0.1.4",
+    "get-stream": "3.0.0",
+    "is-redirect": "1.0.0",
+    "is-retry-allowed": "1.1.0",
+    "is-stream": "1.1.0",
+    "lowercase-keys": "1.0.0",
+    "safe-buffer": "5.1.1",
+    "timed-out": "4.0.1",
+    "unzip-response": "2.0.1",
+    "url-parse-lax": "1.0.0"
+   }
+  },
+  "graceful-fs": {
+   "version": "4.1.11",
+   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+   "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+   "dev": true
+  },
+  "growl": {
+   "version": "1.9.2",
+   "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+   "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+   "dev": true
+  },
+  "gulp-remote-src": {
+   "version": "0.4.2",
+   "resolved": "https://registry.npmjs.org/gulp-remote-src/-/gulp-remote-src-0.4.2.tgz",
+   "integrity": "sha1-zrN3DjREMo1hOG+6qrIAvBHNmKg=",
+   "dev": true,
+   "requires": {
+    "event-stream": "3.3.4",
+    "node.extend": "1.1.6",
+    "request": "2.79.0",
+    "through2": "2.0.3",
+    "vinyl": "2.0.2"
+   }
+  },
+  "gulp-sourcemaps": {
+   "version": "1.6.0",
+   "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+   "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+   "dev": true,
+   "requires": {
+    "convert-source-map": "1.5.0",
+    "graceful-fs": "4.1.11",
+    "strip-bom": "2.0.0",
+    "through2": "2.0.3",
+    "vinyl": "1.2.0"
+   },
+   "dependencies": {
+    "clone-stats": {
+     "version": "0.0.1",
+     "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+     "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+     "dev": true
+    },
+    "replace-ext": {
+     "version": "0.0.1",
+     "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+     "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+     "dev": true
+    },
+    "vinyl": {
+     "version": "1.2.0",
+     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+     "dev": true,
+     "requires": {
+      "clone": "1.0.2",
+      "clone-stats": "0.0.1",
+      "replace-ext": "0.0.1"
+     }
+    }
+   }
+  },
+  "gulp-symdest": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
+   "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
+   "dev": true,
+   "requires": {
+    "event-stream": "3.3.4",
+    "mkdirp": "0.5.1",
+    "queue": "3.1.0",
+    "vinyl-fs": "2.4.4"
+   }
+  },
+  "gulp-vinyl-zip": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-1.4.0.tgz",
+   "integrity": "sha1-VjgvLMtXIxuwR4x4c3zNVylzvuE=",
+   "dev": true,
+   "requires": {
+    "event-stream": "3.3.4",
+    "queue": "3.1.0",
+    "through2": "0.6.5",
+    "vinyl": "0.4.6",
+    "vinyl-fs": "2.4.4",
+    "yauzl": "2.8.0",
+    "yazl": "2.4.2"
+   },
+   "dependencies": {
+    "clone": {
+     "version": "0.2.0",
+     "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+     "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+     "dev": true
+    },
+    "clone-stats": {
+     "version": "0.0.1",
+     "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+     "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+     "dev": true
+    },
+    "isarray": {
+     "version": "0.0.1",
+     "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+     "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+     "dev": true
+    },
+    "readable-stream": {
+     "version": "1.0.34",
+     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+     "dev": true,
+     "requires": {
+      "core-util-is": "1.0.2",
+      "inherits": "2.0.3",
+      "isarray": "0.0.1",
+      "string_decoder": "0.10.31"
+     }
+    },
+    "string_decoder": {
+     "version": "0.10.31",
+     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+     "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+     "dev": true
+    },
+    "through2": {
+     "version": "0.6.5",
+     "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+     "dev": true,
+     "requires": {
+      "readable-stream": "1.0.34",
+      "xtend": "4.0.1"
+     }
+    },
+    "vinyl": {
+     "version": "0.4.6",
+     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+     "dev": true,
+     "requires": {
+      "clone": "0.2.0",
+      "clone-stats": "0.0.1"
+     }
+    }
+   }
+  },
+  "har-validator": {
+   "version": "2.0.6",
+   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+   "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+   "dev": true,
+   "requires": {
+    "chalk": "1.1.3",
+    "commander": "2.11.0",
+    "is-my-json-valid": "2.16.0",
+    "pinkie-promise": "2.0.1"
+   }
+  },
+  "has-ansi": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+   "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+   "dev": true,
+   "requires": {
+    "ansi-regex": "2.1.1"
+   }
+  },
+  "hawk": {
+   "version": "3.1.3",
+   "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+   "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+   "dev": true,
+   "requires": {
+    "boom": "2.10.1",
+    "cryptiles": "2.0.5",
+    "hoek": "2.16.3",
+    "sntp": "1.0.9"
+   }
+  },
+  "hoek": {
+   "version": "2.16.3",
+   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+   "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+   "dev": true
+  },
+  "http-signature": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+   "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+   "dev": true,
+   "requires": {
+    "assert-plus": "0.2.0",
+    "jsprim": "1.4.0",
+    "sshpk": "1.13.1"
+   }
+  },
+  "hubot-cute-me": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/hubot-cute-me/-/hubot-cute-me-1.0.0.tgz",
+   "integrity": "sha1-kwJNlh3jH6b7lCYKkx5y65frr8Q=",
+   "requires": {
+    "coffee-script": "1.6.3"
+   }
+  },
+  "inflight": {
+   "version": "1.0.6",
+   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+   "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+   "dev": true,
+   "requires": {
+    "once": "1.4.0",
+    "wrappy": "1.0.2"
+   }
+  },
+  "inherits": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+   "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+   "dev": true
+  },
+  "is": {
+   "version": "3.2.1",
+   "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
+   "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
+   "dev": true
+  },
+  "is-buffer": {
+   "version": "1.1.5",
+   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+   "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+   "dev": true
+  },
+  "is-dotfile": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+   "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+   "dev": true
+  },
+  "is-equal-shallow": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+   "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+   "dev": true,
+   "requires": {
+    "is-primitive": "2.0.0"
+   }
+  },
+  "is-extendable": {
+   "version": "0.1.1",
+   "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+   "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+   "dev": true
+  },
+  "is-extglob": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+   "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+   "dev": true
+  },
+  "is-glob": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+   "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+   "dev": true,
+   "requires": {
+    "is-extglob": "2.1.1"
+   }
+  },
+  "is-my-json-valid": {
+   "version": "2.16.0",
+   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+   "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+   "dev": true,
+   "requires": {
+    "generate-function": "2.0.0",
+    "generate-object-property": "1.2.0",
+    "jsonpointer": "4.0.1",
+    "xtend": "4.0.1"
+   }
+  },
+  "is-number": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+   "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+   "dev": true,
+   "requires": {
+    "kind-of": "3.2.2"
+   }
+  },
+  "is-posix-bracket": {
+   "version": "0.1.1",
+   "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+   "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+   "dev": true
+  },
+  "is-primitive": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+   "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+   "dev": true
+  },
+  "is-property": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+   "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+   "dev": true
+  },
+  "is-redirect": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+   "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+  },
+  "is-retry-allowed": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+   "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+  },
+  "is-stream": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+   "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+  },
+  "is-typedarray": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+   "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+   "dev": true
+  },
+  "is-utf8": {
+   "version": "0.2.1",
+   "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+   "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+   "dev": true
+  },
+  "is-valid-glob": {
+   "version": "0.3.0",
+   "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+   "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+   "dev": true
+  },
+  "isarray": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+   "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+   "dev": true
+  },
+  "isobject": {
+   "version": "2.1.0",
+   "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+   "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+   "dev": true,
+   "requires": {
+    "isarray": "1.0.0"
+   }
+  },
+  "isstream": {
+   "version": "0.1.2",
+   "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+   "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+   "dev": true
+  },
+  "jade": {
+   "version": "0.26.3",
+   "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+   "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+   "dev": true,
+   "requires": {
+    "commander": "0.6.1",
+    "mkdirp": "0.3.0"
+   },
+   "dependencies": {
+    "commander": {
+     "version": "0.6.1",
+     "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+     "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+     "dev": true
+    },
+    "mkdirp": {
+     "version": "0.3.0",
+     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+     "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+     "dev": true
+    }
+   }
+  },
+  "jsbn": {
+   "version": "0.1.1",
+   "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+   "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+   "dev": true,
+   "optional": true
+  },
+  "json-schema": {
+   "version": "0.2.3",
+   "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+   "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+   "dev": true
+  },
+  "json-stable-stringify": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+   "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+   "dev": true,
+   "requires": {
+    "jsonify": "0.0.0"
+   }
+  },
+  "json-stringify-safe": {
+   "version": "5.0.1",
+   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+   "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+   "dev": true
+  },
+  "jsonify": {
+   "version": "0.0.0",
+   "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+   "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+   "dev": true
+  },
+  "jsonpointer": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+   "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+   "dev": true
+  },
+  "jsprim": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+   "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+   "dev": true,
+   "requires": {
+    "assert-plus": "1.0.0",
+    "extsprintf": "1.0.2",
+    "json-schema": "0.2.3",
+    "verror": "1.3.6"
+   },
+   "dependencies": {
+    "assert-plus": {
+     "version": "1.0.0",
+     "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+     "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+     "dev": true
+    }
+   }
+  },
+  "kind-of": {
+   "version": "3.2.2",
+   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+   "dev": true,
+   "requires": {
+    "is-buffer": "1.1.5"
+   }
+  },
+  "lazystream": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+   "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+   "dev": true,
+   "requires": {
+    "readable-stream": "2.3.3"
+   }
+  },
+  "lodash.isequal": {
+   "version": "4.5.0",
+   "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+   "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+   "dev": true
+  },
+  "lowercase-keys": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+   "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+  },
+  "lru-cache": {
+   "version": "2.7.3",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+   "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+   "dev": true
+  },
+  "map-stream": {
+   "version": "0.1.0",
+   "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+   "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+   "dev": true
+  },
+  "merge-stream": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+   "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+   "dev": true,
+   "requires": {
+    "readable-stream": "2.3.3"
+   }
+  },
+  "micromatch": {
+   "version": "2.3.11",
+   "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+   "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+   "dev": true,
+   "requires": {
+    "arr-diff": "2.0.0",
+    "array-unique": "0.2.1",
+    "braces": "1.8.5",
+    "expand-brackets": "0.1.5",
+    "extglob": "0.3.2",
+    "filename-regex": "2.0.1",
+    "is-extglob": "1.0.0",
+    "is-glob": "2.0.1",
+    "kind-of": "3.2.2",
+    "normalize-path": "2.1.1",
+    "object.omit": "2.0.1",
+    "parse-glob": "3.0.4",
+    "regex-cache": "0.4.3"
+   },
+   "dependencies": {
+    "is-extglob": {
+     "version": "1.0.0",
+     "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+     "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+     "dev": true
+    },
+    "is-glob": {
+     "version": "2.0.1",
+     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+     "dev": true,
+     "requires": {
+      "is-extglob": "1.0.0"
+     }
+    }
+   }
+  },
+  "mime-db": {
+   "version": "1.27.0",
+   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+   "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+   "dev": true
+  },
+  "mime-types": {
+   "version": "2.1.15",
+   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+   "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+   "dev": true,
+   "requires": {
+    "mime-db": "1.27.0"
+   }
+  },
+  "minimatch": {
+   "version": "3.0.4",
+   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+   "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+   "dev": true,
+   "requires": {
+    "brace-expansion": "1.1.8"
+   }
+  },
+  "minimist": {
+   "version": "0.0.8",
+   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+   "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+   "dev": true
+  },
+  "mkdirp": {
+   "version": "0.5.1",
+   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+   "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+   "dev": true,
+   "requires": {
+    "minimist": "0.0.8"
+   }
+  },
+  "mocha": {
+   "version": "2.5.3",
+   "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+   "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+   "dev": true,
+   "requires": {
+    "commander": "2.3.0",
+    "debug": "2.2.0",
+    "diff": "1.4.0",
+    "escape-string-regexp": "1.0.2",
+    "glob": "3.2.11",
+    "growl": "1.9.2",
+    "jade": "0.26.3",
+    "mkdirp": "0.5.1",
+    "supports-color": "1.2.0",
+    "to-iso-string": "0.0.2"
+   },
+   "dependencies": {
+    "commander": {
+     "version": "2.3.0",
+     "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+     "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+     "dev": true
+    },
+    "escape-string-regexp": {
+     "version": "1.0.2",
+     "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+     "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+     "dev": true
+    },
+    "glob": {
+     "version": "3.2.11",
+     "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+     "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+     "dev": true,
+     "requires": {
+      "inherits": "2.0.3",
+      "minimatch": "0.3.0"
+     }
+    },
+    "minimatch": {
+     "version": "0.3.0",
+     "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+     "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+     "dev": true,
+     "requires": {
+      "lru-cache": "2.7.3",
+      "sigmund": "1.0.1"
+     }
+    },
+    "supports-color": {
+     "version": "1.2.0",
+     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+     "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+     "dev": true
+    }
+   }
+  },
+  "ms": {
+   "version": "0.7.1",
+   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+   "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+   "dev": true
+  },
+  "node.extend": {
+   "version": "1.1.6",
+   "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
+   "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
+   "dev": true,
+   "requires": {
+    "is": "3.2.1"
+   }
+  },
+  "normalize-path": {
+   "version": "2.1.1",
+   "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+   "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+   "dev": true,
+   "requires": {
+    "remove-trailing-separator": "1.0.2"
+   }
+  },
+  "oauth-sign": {
+   "version": "0.8.2",
+   "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+   "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+   "dev": true
+  },
+  "object-assign": {
+   "version": "4.1.1",
+   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+   "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+   "dev": true
+  },
+  "object.omit": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+   "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+   "dev": true,
+   "requires": {
+    "for-own": "0.1.5",
+    "is-extendable": "0.1.1"
+   }
+  },
+  "once": {
+   "version": "1.4.0",
+   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+   "dev": true,
+   "requires": {
+    "wrappy": "1.0.2"
+   }
+  },
+  "open": {
+   "version": "0.0.5",
+   "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
+   "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw="
+  },
+  "ordered-read-streams": {
+   "version": "0.3.0",
+   "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+   "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+   "dev": true,
+   "requires": {
+    "is-stream": "1.1.0",
+    "readable-stream": "2.3.3"
+   }
+  },
+  "parse-glob": {
+   "version": "3.0.4",
+   "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+   "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+   "dev": true,
+   "requires": {
+    "glob-base": "0.3.0",
+    "is-dotfile": "1.0.3",
+    "is-extglob": "1.0.0",
+    "is-glob": "2.0.1"
+   },
+   "dependencies": {
+    "is-extglob": {
+     "version": "1.0.0",
+     "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+     "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+     "dev": true
+    },
+    "is-glob": {
+     "version": "2.0.1",
+     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+     "dev": true,
+     "requires": {
+      "is-extglob": "1.0.0"
+     }
+    }
+   }
+  },
+  "path-dirname": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+   "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+   "dev": true
+  },
+  "path-is-absolute": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+   "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+   "dev": true
+  },
+  "pause-stream": {
+   "version": "0.0.11",
+   "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+   "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+   "dev": true,
+   "requires": {
+    "through": "2.3.8"
+   }
+  },
+  "pend": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+   "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+   "dev": true
+  },
+  "pinkie": {
+   "version": "2.0.4",
+   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+   "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+   "dev": true
+  },
+  "pinkie-promise": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+   "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+   "dev": true,
+   "requires": {
+    "pinkie": "2.0.4"
+   }
+  },
+  "prepend-http": {
+   "version": "1.0.4",
+   "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+   "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+  },
+  "preserve": {
+   "version": "0.2.0",
+   "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+   "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+   "dev": true
+  },
+  "process-nextick-args": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+   "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+   "dev": true
+  },
+  "punycode": {
+   "version": "1.4.1",
+   "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+   "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+   "dev": true
+  },
+  "qs": {
+   "version": "6.3.2",
+   "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+   "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+   "dev": true
+  },
+  "queue": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
+   "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
+   "dev": true,
+   "requires": {
+    "inherits": "2.0.3"
+   }
+  },
+  "random-number-generator": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/random-number-generator/-/random-number-generator-1.0.2.tgz",
+   "integrity": "sha1-kl4y4cevIfd8iU/zRFubHN3Zfvw="
+  },
+  "random-puppy": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/random-puppy/-/random-puppy-1.1.0.tgz",
+   "integrity": "sha1-GtqjTA83bVArWdb9gifqYaRUmTs=",
+   "requires": {
+    "eventemitter3": "1.2.0",
+    "got": "6.7.1",
+    "unique-random-array": "1.0.0"
+   }
+  },
+  "randomatic": {
+   "version": "1.1.7",
+   "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+   "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+   "dev": true,
+   "requires": {
+    "is-number": "3.0.0",
+    "kind-of": "4.0.0"
+   },
+   "dependencies": {
+    "is-number": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+     "dev": true,
+     "requires": {
+      "kind-of": "3.2.2"
+     },
+     "dependencies": {
+      "kind-of": {
+       "version": "3.2.2",
+       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+       "dev": true,
+       "requires": {
+        "is-buffer": "1.1.5"
+       }
+      }
+     }
+    },
+    "kind-of": {
+     "version": "4.0.0",
+     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+     "dev": true,
+     "requires": {
+      "is-buffer": "1.1.5"
+     }
+    }
+   }
+  },
+  "readable-stream": {
+   "version": "2.3.3",
+   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+   "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+   "dev": true,
+   "requires": {
+    "core-util-is": "1.0.2",
+    "inherits": "2.0.3",
+    "isarray": "1.0.0",
+    "process-nextick-args": "1.0.7",
+    "safe-buffer": "5.1.1",
+    "string_decoder": "1.0.3",
+    "util-deprecate": "1.0.2"
+   }
+  },
+  "regex-cache": {
+   "version": "0.4.3",
+   "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+   "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+   "dev": true,
+   "requires": {
+    "is-equal-shallow": "0.1.3",
+    "is-primitive": "2.0.0"
+   }
+  },
+  "remove-trailing-separator": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+   "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
+   "dev": true
+  },
+  "repeat": {
+   "version": "0.0.6",
+   "resolved": "https://registry.npmjs.org/repeat/-/repeat-0.0.6.tgz",
+   "integrity": "sha1-bJ2BM+uM6vjjgPBsabUUF7fLDo0=",
+   "requires": {
+    "dfrrd": "0.2.0"
+   }
+  },
+  "repeat-element": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+   "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+   "dev": true
+  },
+  "repeat-string": {
+   "version": "1.6.1",
+   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+   "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+   "dev": true
+  },
+  "replace-ext": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+   "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+   "dev": true
+  },
+  "request": {
+   "version": "2.79.0",
+   "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+   "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+   "dev": true,
+   "requires": {
+    "aws-sign2": "0.6.0",
+    "aws4": "1.6.0",
+    "caseless": "0.11.0",
+    "combined-stream": "1.0.5",
+    "extend": "3.0.1",
+    "forever-agent": "0.6.1",
+    "form-data": "2.1.4",
+    "har-validator": "2.0.6",
+    "hawk": "3.1.3",
+    "http-signature": "1.1.1",
+    "is-typedarray": "1.0.0",
+    "isstream": "0.1.2",
+    "json-stringify-safe": "5.0.1",
+    "mime-types": "2.1.15",
+    "oauth-sign": "0.8.2",
+    "qs": "6.3.2",
+    "stringstream": "0.0.5",
+    "tough-cookie": "2.3.2",
+    "tunnel-agent": "0.4.3",
+    "uuid": "3.1.0"
+   }
+  },
+  "safe-buffer": {
+   "version": "5.1.1",
+   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+   "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+  },
+  "sigmund": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+   "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+   "dev": true
+  },
+  "sntp": {
+   "version": "1.0.9",
+   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+   "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+   "dev": true,
+   "requires": {
+    "hoek": "2.16.3"
+   }
+  },
+  "source-map": {
+   "version": "0.1.32",
+   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+   "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
+   "dev": true,
+   "requires": {
+    "amdefine": "1.0.1"
+   }
+  },
+  "source-map-support": {
+   "version": "0.3.3",
+   "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.3.tgz",
+   "integrity": "sha1-NJAJd9W6PwfHdX7nLnO7GptTdU8=",
+   "dev": true,
+   "requires": {
+    "source-map": "0.1.32"
+   }
+  },
+  "split": {
+   "version": "0.3.3",
+   "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+   "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+   "dev": true,
+   "requires": {
+    "through": "2.3.8"
+   }
+  },
+  "sshpk": {
+   "version": "1.13.1",
+   "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+   "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+   "dev": true,
+   "requires": {
+    "asn1": "0.2.3",
+    "assert-plus": "1.0.0",
+    "bcrypt-pbkdf": "1.0.1",
+    "dashdash": "1.14.1",
+    "ecc-jsbn": "0.1.1",
+    "getpass": "0.1.7",
+    "jsbn": "0.1.1",
+    "tweetnacl": "0.14.5"
+   },
+   "dependencies": {
+    "assert-plus": {
+     "version": "1.0.0",
+     "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+     "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+     "dev": true
+    }
+   }
+  },
+  "stream-combiner": {
+   "version": "0.0.4",
+   "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+   "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+   "dev": true,
+   "requires": {
+    "duplexer": "0.1.1"
+   }
+  },
+  "stream-shift": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+   "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+   "dev": true
+  },
+  "string_decoder": {
+   "version": "1.0.3",
+   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+   "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+   "dev": true,
+   "requires": {
+    "safe-buffer": "5.1.1"
+   }
+  },
+  "stringstream": {
+   "version": "0.0.5",
+   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+   "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+   "dev": true
+  },
+  "strip-ansi": {
+   "version": "3.0.1",
+   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+   "dev": true,
+   "requires": {
+    "ansi-regex": "2.1.1"
+   }
+  },
+  "strip-bom": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+   "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+   "dev": true,
+   "requires": {
+    "is-utf8": "0.2.1"
+   }
+  },
+  "strip-bom-stream": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+   "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+   "dev": true,
+   "requires": {
+    "first-chunk-stream": "1.0.0",
+    "strip-bom": "2.0.0"
+   }
+  },
+  "supports-color": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+   "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+   "dev": true
+  },
+  "through": {
+   "version": "2.3.8",
+   "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+   "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+   "dev": true
+  },
+  "through2": {
+   "version": "2.0.3",
+   "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+   "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+   "dev": true,
+   "requires": {
+    "readable-stream": "2.3.3",
+    "xtend": "4.0.1"
+   }
+  },
+  "through2-filter": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+   "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+   "dev": true,
+   "requires": {
+    "through2": "2.0.3",
+    "xtend": "4.0.1"
+   }
+  },
+  "timed-out": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+   "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+  },
+  "to-absolute-glob": {
+   "version": "0.1.1",
+   "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+   "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+   "dev": true,
+   "requires": {
+    "extend-shallow": "2.0.1"
+   }
+  },
+  "to-iso-string": {
+   "version": "0.0.2",
+   "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+   "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+   "dev": true
+  },
+  "tough-cookie": {
+   "version": "2.3.2",
+   "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+   "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+   "dev": true,
+   "requires": {
+    "punycode": "1.4.1"
+   }
+  },
+  "tunnel-agent": {
+   "version": "0.4.3",
+   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+   "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+   "dev": true
+  },
+  "tweetnacl": {
+   "version": "0.14.5",
+   "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+   "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+   "dev": true,
+   "optional": true
+  },
+  "typescript": {
+   "version": "1.8.10",
+   "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.8.10.tgz",
+   "integrity": "sha1-tHXW4N/wv1DyluXKbvn7tccyDx4=",
+   "dev": true
+  },
+  "unique-random": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/unique-random/-/unique-random-1.0.0.tgz",
+   "integrity": "sha1-zj4iTIJCzTOg53sNcYDXfmti0MQ="
+  },
+  "unique-random-array": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/unique-random-array/-/unique-random-array-1.0.0.tgz",
+   "integrity": "sha1-QrNyHFeTiNi2Z8k8Lb3j1dgakTY=",
+   "requires": {
+    "unique-random": "1.0.0"
+   }
+  },
+  "unique-stream": {
+   "version": "2.2.1",
+   "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+   "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+   "dev": true,
+   "requires": {
+    "json-stable-stringify": "1.0.1",
+    "through2-filter": "2.0.0"
+   }
+  },
+  "unzip-response": {
+   "version": "2.0.1",
+   "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+   "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+  },
+  "url-parse-lax": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+   "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+   "requires": {
+    "prepend-http": "1.0.4"
+   }
+  },
+  "util-deprecate": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+   "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+   "dev": true
+  },
+  "uuid": {
+   "version": "3.1.0",
+   "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+   "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+   "dev": true
+  },
+  "vali-date": {
+   "version": "1.0.0",
+   "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+   "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+   "dev": true
+  },
+  "verror": {
+   "version": "1.3.6",
+   "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+   "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+   "dev": true,
+   "requires": {
+    "extsprintf": "1.0.2"
+   }
+  },
+  "vinyl": {
+   "version": "2.0.2",
+   "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
+   "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
+   "dev": true,
+   "requires": {
+    "clone": "1.0.2",
+    "clone-buffer": "1.0.0",
+    "clone-stats": "1.0.0",
+    "cloneable-readable": "1.0.0",
+    "is-stream": "1.1.0",
+    "remove-trailing-separator": "1.0.2",
+    "replace-ext": "1.0.0"
+   }
+  },
+  "vinyl-fs": {
+   "version": "2.4.4",
+   "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+   "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+   "dev": true,
+   "requires": {
+    "duplexify": "3.5.0",
+    "glob-stream": "5.3.5",
+    "graceful-fs": "4.1.11",
+    "gulp-sourcemaps": "1.6.0",
+    "is-valid-glob": "0.3.0",
+    "lazystream": "1.0.0",
+    "lodash.isequal": "4.5.0",
+    "merge-stream": "1.0.1",
+    "mkdirp": "0.5.1",
+    "object-assign": "4.1.1",
+    "readable-stream": "2.3.3",
+    "strip-bom": "2.0.0",
+    "strip-bom-stream": "1.0.0",
+    "through2": "2.0.3",
+    "through2-filter": "2.0.0",
+    "vali-date": "1.0.0",
+    "vinyl": "1.2.0"
+   },
+   "dependencies": {
+    "clone-stats": {
+     "version": "0.0.1",
+     "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+     "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+     "dev": true
+    },
+    "replace-ext": {
+     "version": "0.0.1",
+     "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+     "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+     "dev": true
+    },
+    "vinyl": {
+     "version": "1.2.0",
+     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+     "dev": true,
+     "requires": {
+      "clone": "1.0.2",
+      "clone-stats": "0.0.1",
+      "replace-ext": "0.0.1"
+     }
+    }
+   }
+  },
+  "vscode": {
+   "version": "0.10.7",
+   "resolved": "https://registry.npmjs.org/vscode/-/vscode-0.10.7.tgz",
+   "integrity": "sha1-9dKJcI7nmmbC4zREy4MY2mJgt40=",
+   "dev": true,
+   "requires": {
+    "glob": "5.0.15",
+    "gulp-remote-src": "0.4.2",
+    "gulp-symdest": "1.1.0",
+    "gulp-vinyl-zip": "1.4.0",
+    "mocha": "2.5.3",
+    "source-map-support": "0.3.3"
+   }
+  },
+  "wrappy": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+   "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+   "dev": true
+  },
+  "xtend": {
+   "version": "4.0.1",
+   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+   "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+   "dev": true
+  },
+  "yauzl": {
+   "version": "2.8.0",
+   "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz",
+   "integrity": "sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI=",
+   "dev": true,
+   "requires": {
+    "buffer-crc32": "0.2.13",
+    "fd-slicer": "1.0.1"
+   }
+  },
+  "yazl": {
+   "version": "2.4.2",
+   "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.2.tgz",
+   "integrity": "sha1-FMsZCD4eJacAksFYiqvg9OTdTYg=",
+   "dev": true,
+   "requires": {
+    "buffer-crc32": "0.2.13"
+   }
+  }
+ }
+}

--- a/package.json
+++ b/package.json
@@ -1,66 +1,72 @@
 {
-	"name": "puppypopup",
-	"displayName": "Puppy Generator",
-	"description": "Take a break from coding with puppies",
-	"version": "0.0.2",
-	"publisher": "StineTheBean",
-	"engines": {
-		"vscode": "^0.10.1"
-	},
-    "license": "MIT",
-    "homepage":"https://github.com/stinethebean/Puppy-Generating-VScode-extension",
-	"categories": [
-		"Other"
-	],
-    "keywords": [
-        "Puppy",
-        "Puppies",
-        "Fun",
-        "Silly"
-    ],
-    "icon": "PuppyLogo.png",
-    "galleryBanner": {
-    "color": "#A1A0A0",
-    "theme": "light"
-     },
-     "bugs": {
-         "url":"https://github.com/stinethebean/Puppy-Generating-VScode-extension",
-         "email":"christineatms@gmail.com"
-     },
-	"activationEvents": [
-		"onCommand:extension.sayHello",
-        "onCommand:extension.randomPuppy",
-        "onCommand:extension.hourlyPuppy",
-        "onCommand:extension.randomCute"
-	],
-	"main": "./out/src/extension",
-	"contributes": {
-		"commands": [
-         {
-			"command": "extension.sayHello",
-			"title": "Puppy: Instant puppy"
-		},
-        {
-            "command": "extension.randomPuppy",
-            "title": "Puppy: Get puppies randomly for the next 4 hours"    
-        },
-        {
-            "command": "extension.hourlyPuppy",
-            "title": "Puppy: Get puppies hourly"
-        },
-        {
-            "command": "extension.randomCute",
-            "title": "Random cute image of the day"
-        }
-        
-        ]
-	},
-	"scripts": {
-		"vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-		"compile": "node ./node_modules/vscode/bin/compile -watch -p ./"
-	},
-	"devDependencies": {
-		"typescript": "^1.6.2",
-		"vscode": "0.10.x"
-	}
+ "name": "puppypopup",
+ "displayName": "Puppy Generator",
+ "description": "Take a break from coding with puppies",
+ "version": "0.0.3",
+ "publisher": "StineTheBean",
+ "engines": {
+  "vscode": "^0.10.1"
+ },
+ "license": "MIT",
+ "homepage": "https://github.com/stinethebean/Puppy-Generating-VScode-extension",
+ "categories": [
+  "Other"
+ ],
+ "keywords": [
+  "Puppy",
+  "Puppies",
+  "Fun",
+  "Silly"
+ ],
+ "icon": "PuppyLogo.png",
+ "galleryBanner": {
+  "color": "#A1A0A0",
+  "theme": "light"
+ },
+ "bugs": {
+  "url": "https://github.com/stinethebean/Puppy-Generating-VScode-extension",
+  "email": "christineatms@gmail.com"
+ },
+ "activationEvents": [
+  "onCommand:extension.sayHello",
+  "onCommand:extension.randomPuppy",
+  "onCommand:extension.hourlyPuppy",
+  "onCommand:extension.randomCute"
+ ],
+ "main": "./out/src/extension",
+ "contributes": {
+  "commands": [
+   {
+    "command": "extension.sayHello",
+    "title": "Puppy: Instant puppy"
+   },
+   {
+    "command": "extension.randomPuppy",
+    "title": "Puppy: Get puppies randomly for the next 4 hours"
+   },
+   {
+    "command": "extension.hourlyPuppy",
+    "title": "Puppy: Get puppies hourly"
+   },
+   {
+    "command": "extension.randomCute",
+    "title": "Random cute image of the day"
+   }
+  ]
+ },
+ "scripts": {
+  "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
+  "compile": "node ./node_modules/vscode/bin/compile -watch -p ./"
+ },
+ "devDependencies": {
+  "typescript": "^1.6.2",
+  "vscode": "0.10.x"
+ },
+ "dependencies": {
+  "hubot-cute-me": "^1.0.0",
+  "open": "0.0.5",
+  "random-number-generator": "^1.0.2",
+  "random-puppy": "^1.1.0",
+  "repeat": "0.0.6"
+ }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,50 +1,54 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-import * as vscode from 'vscode'; 
+import * as vscode from 'vscode';
+const puppy = require('random-puppy');
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
 
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "puppypopup" is now active!'); 
+    // Use the console to output diagnostic information (console.log) and errors (console.error)
+    // This line of code will only be executed once when your extension is activated
+    console.log('Congratulations, your extension "puppypopup" is now active!');
 
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with  registerCommand
-	// The commandId parameter must match the command field in package.json
-	var open = require("open");
-	var disposable = vscode.commands.registerCommand('extension.sayHello', () => openPuppy());
+    // The command has been defined in the package.json file
+    // Now provide the implementation of the command with  registerCommand
+    // The commandId parameter must match the command field in package.json
+    var open = require("open");
+    var disposable = vscode.commands.registerCommand('extension.sayHello', () => openPuppy());
     var disposable = vscode.commands.registerCommand('extension.randomPuppy', () => randomPuppy());
     var disposable = vscode.commands.registerCommand('extension.hourlyPuppy', () => hourlyPuppy());
     var disposable = vscode.commands.registerCommand('extension.randomCute', () => randomCuteThing());
-    
-	
-	context.subscriptions.push(disposable);
+
+
+    context.subscriptions.push(disposable);
 }
 
-function puppyTimer(time){
+function puppyTimer(time) {
     var repeat = require('repeat');
     repeat(openPuppy).every(time, 'minutes').for(4, 'hours').start.in(5, 'sec');
 }
 
-function randomPuppy(){
+function randomPuppy() {
     var random = require('random-number-generator')
-    var minutes = random(60,15);
+    var minutes = random(60, 15);
     puppyTimer(minutes);
 }
 
-function hourlyPuppy(){
+function hourlyPuppy() {
     puppyTimer(60);
 }
 
 
-function openPuppy(){
+function openPuppy() {
     var open = require('open');
-    open("http://www.thepuppyapi.com/puppy?format=src");
+    puppy()
+        .then(url => {
+            open(url);
+        });
 }
 
-function randomCuteThing(){
+function randomCuteThing() {
     var open = require('open');
     var cute = require('hubot-cute-me');
     open(cute());


### PR DESCRIPTION
I really like having silly add-ons like these to take a break every now and then, so I wanted to fix a tiny problem you were having - the old API no longer returned glorious puppy photos. 

By using [random-puppy](https://www.npmjs.com/package/random-puppy) to fetch images, the 404 should hopefully disappear for a while. random-puppy fetches images from the reddit/r/puppy, and should the reddit api change, then I guess I'll deal with that later. It should be pretty stable!

Please consider this PR, and keep up the good work!